### PR TITLE
modify a parent view of PagingFocusView

### DIFF
--- a/PagingKit/PagingMenuView.swift
+++ b/PagingKit/PagingMenuView.swift
@@ -360,7 +360,7 @@ public class PagingMenuView: UIScrollView {
     
     private func configureFocusView() {
         focusView.frame = .zero
-        addSubview(focusView)
+        containerView.addSubview(focusView)
     }
     
     private func configureView() {

--- a/PagingKit/PagingMenuViewController.swift
+++ b/PagingKit/PagingMenuViewController.swift
@@ -115,6 +115,16 @@ public class PagingMenuViewController: UIViewController {
             return menuView.cellSpacing
         }
     }
+    
+    /// The content inset to add padding
+    public var contentInset: UIEdgeInsets {
+        set {
+            menuView.contentInset = newValue
+        }
+        get {
+            return menuView.contentInset
+        }
+    }
 
     /// Scrolls a specific index of the menu so that it is visible in the receiver.
     ///


### PR DESCRIPTION
-  UIPagingMenuView.contentInsets adds padding to the menu elements.
- In that case, UIPagingFocusView has a wrong origin because the parent view is wrong.

https://github.com/kazuhiro4949/PagingKit/issues/24