### PR TITLE
fixu PagingMenuView Scrolling methods

### DIFF
--- a/PagingKit/PagingMenuView.swift
+++ b/PagingKit/PagingMenuView.swift
@@ -292,9 +292,7 @@ public class PagingMenuView: UIScrollView {
     /// - Parameters:
     ///   - index: A index defining an menu of the menu view.
     ///   - percent: A rate that transit from the index.
-    ///   - animated: true if the scrolling should be animated, false if it should be immediate.
-    ///   - baseBounds: a rect base boounds to calculate position and size
-    public func scroll(index: Int, percent: CGFloat = 0, animated: Bool = true) {
+    public func scroll(index: Int, percent: CGFloat = 0) {
         let rightIndex = index + 1
         let leftFrame = rectForItem(at: index)
         let rightFrame = rectForItem(at: rightIndex)
@@ -307,7 +305,7 @@ public class PagingMenuView: UIScrollView {
         let normaizedOffsetX = min(max(minContentOffsetX, offsetX), maxContentOffsetX)
         focusView.center = CGPoint(x: centerPointX, y: center.y)
         
-        setContentOffset(CGPoint(x: normaizedOffsetX, y:0), animated: animated)
+        contentOffset = CGPoint(x: normaizedOffsetX, y:0)
         focusView.selectedIndex = index
     }
     

--- a/PagingKitTests/PagingMenuViewControllerTests.swift
+++ b/PagingKitTests/PagingMenuViewControllerTests.swift
@@ -58,7 +58,7 @@ class PagingMenuViewControllerTests: XCTestCase {
         XCTAssertEqual(actualScrollOrder, randamizedScrollOrder, "focus correct cell")
     }
     
-    func testEnabledToHookCompletionAfterReloadData() {
+    func testHookCompletionHandlerAfterReloadData() {
         let dataSource = MenuViewControllerDataSourceMock()
         let menuViewController = PagingMenuViewControllerTests.makeViewController(with: dataSource)
         dataSource.registerNib(to: menuViewController)

--- a/PagingKitTests/PagingMenuViewControllerTests.swift
+++ b/PagingKitTests/PagingMenuViewControllerTests.swift
@@ -58,6 +58,25 @@ class PagingMenuViewControllerTests: XCTestCase {
         XCTAssertEqual(actualScrollOrder, randamizedScrollOrder, "focus correct cell")
     }
     
+    func testEnabledToHookCompletionAfterReloadData() {
+        let dataSource = MenuViewControllerDataSourceMock()
+        let menuViewController = PagingMenuViewControllerTests.makeViewController(with: dataSource)
+        dataSource.registerNib(to: menuViewController)
+        
+        let expectation = XCTestExpectation(description: "finish load")
+        menuViewController.reloadData(with: 15) { [menuViewController = menuViewController] (_) in
+            let minX = menuViewController.menuView.rectForItem(at: 15).midX
+            let expectedContentOffsetX = minX - floor(menuViewController.menuView.bounds.width / 2)
+            XCTAssertEqual(
+                menuViewController.menuView.contentOffset,
+                CGPoint(x: expectedContentOffsetX, y: 0),
+                "PagingMenuViewController has completely finished reloading"
+            )
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+    
     func testSelectedIndexIsNotNilDuringReloadData() {
         let dataSource = MenuViewControllerDataSourceMock()
         let menuViewController = PagingMenuViewControllerTests.makeViewController(with: dataSource)


### PR DESCRIPTION
The completionHandler of ```PagingMenuViewControllr.reloadData(with:completionHandler:)``` is not called when the index is out of screen.
I wrapped  PagingMenuView.setContentOffset() in UIView.animate(animation:completion:).