### PR TITLE
fix complete handler for setting contentOffset

### DIFF
--- a/PagingKit/PagingContentViewController.swift
+++ b/PagingKit/PagingContentViewController.swift
@@ -170,14 +170,9 @@ public class PagingContentViewController: UIViewController {
                 self?.view.layoutIfNeeded()
             },
             completion: { [weak self] _ in
-                UIView.pk.catchLayoutCompletion(
-                    layout: { [weak self] in
-                        self?.scroll(to: page, animated: false)
-                    },
-                    completion: {  _ in
-                        completion?()
-                    }
-                )
+                self?.scroll(to: page, animated: false) { _ in
+                    completion?()
+                }
             }
         )
     }
@@ -187,20 +182,21 @@ public class PagingContentViewController: UIViewController {
     /// - Parameters:
     ///   - page: A index defining an content of the content view controller.
     ///   - animated: true if the scrolling should be animated, false if it should be immediate.
-    public func scroll(to page: Int, animated: Bool) {
+    public func scroll(to page: Int, animated: Bool, completion: ((Bool) -> Void)? = nil) {
         delegate?.contentViewController(viewController: self, willBeginPagingAt: leftSidePageIndex, animated: animated)
         
         loadPagesIfNeeded(page: page)
         leftSidePageIndex = page
         
         delegate?.contentViewController(viewController: self, willFinishPagingAt: leftSidePageIndex, animated: animated)
-        scroll(to: page, animated: animated) { [weak self] (finished) in
+        move(to: page, animated: animated) { [weak self] (finished) in
             guard let _self = self, finished else { return }
+            completion?(finished)
             _self.delegate?.contentViewController(viewController: _self, didFinishPagingAt: _self.leftSidePageIndex, animated: animated)
         }
     }
     
-    private func scroll(to page: Int, animated: Bool, completion: @escaping (Bool) -> Void) {
+    private func move(to page: Int, animated: Bool, completion: @escaping (Bool) -> Void) {
         let offsetX = scrollView.bounds.width * CGFloat(page)
         if animated {
             stopScrolling()

--- a/PagingKit/PagingKitProxy.swift
+++ b/PagingKit/PagingKitProxy.swift
@@ -63,3 +63,34 @@ extension PagingKitProxy where Base == UIColor.Type {
         )
     }
 }
+
+extension PagingKitProxy where Base == UIView.Type {
+    /// call this function to catch completion handler of layoutIfNeeded()
+    ///
+    /// - Parameters:
+    ///   - layout: method which has layoutIfNeeded()
+    ///   - completion: completion handler of layoutIfNeeded()
+    func catchLayoutCompletion(layout: @escaping () -> Void, completion: @escaping (Bool) -> Void) {
+        UIView.animate(withDuration: 0, animations: {
+            layout()
+        }) { (finish) in
+            completion(finish)
+        }
+    }
+    
+    
+    /// perform system like animation
+    ///
+    /// - Parameters:
+    ///   - animations: animation Handler
+    ///   - completion: completion Handler
+    func performSystemAnimation(_ animations: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
+        UIView.perform(
+            .delete,
+            on: [],
+            options: UIViewAnimationOptions(rawValue: 0),
+            animations: animations,
+            completion: completion
+        )
+    }
+}

--- a/PagingKit/PagingMenuViewController.swift
+++ b/PagingKit/PagingMenuViewController.swift
@@ -225,12 +225,12 @@ public class PagingMenuViewController: UIViewController {
     public func reloadData(with preferredFocusIndex: Int? = nil, completionHandler: ((Bool) -> Void)? = nil) {
         let selectedIndex = preferredFocusIndex ?? currentFocusedIndex ?? 0
         menuView.focusView.selectedIndex = selectedIndex
-        catchLayoutCompletion(
+        UIView.pk.catchLayoutCompletion(
             layout: { [weak self] in
                 self?.menuView.reloadData()
             },
             completion: {  [weak self] (finish) in
-                catchLayoutCompletion(
+                UIView.pk.catchLayoutCompletion(
                     layout: { [weak self] in
                         self?.scroll(index: selectedIndex, percent: 0, animated: false)
                     },
@@ -327,19 +327,5 @@ extension PagingMenuViewController: PagingMenuViewDataSource {
 
     public func pagingMenuView(pagingMenuView: PagingMenuView, cellForItemAt index: Int) -> PagingMenuViewCell {
         return dataSource!.menuViewController(viewController: self, cellForItemAt: index)
-    }
-}
-
-
-/// call this function to catch completion handler of layoutIfNeeded()
-///
-/// - Parameters:
-///   - layout: method which has layoutIfNeeded()
-///   - completion: completion handler of layoutIfNeeded()
-func catchLayoutCompletion(layout: @escaping () -> Void, completion: @escaping (Bool) -> Void) {
-    UIView.animate(withDuration: 0, animations: {
-        layout()
-    }) { (finish) in
-        completion(finish)
     }
 }

--- a/PagingKitTests/PagingContentViewControllerTests.swift
+++ b/PagingKitTests/PagingContentViewControllerTests.swift
@@ -83,14 +83,14 @@ class PagingContentViewControllerTests: XCTestCase {
             return
         }
 
-        let dataSource = PagingContentVcDataSourceSpy()
+        let dataSource = PagingContentVcDataSourceSpy(count: 100)
         pagingContentViewController.dataSource = dataSource
         pagingContentViewController.loadViewIfNeeded()
         
         do {
             let expectation = XCTestExpectation(description: "index: 4")
-            pagingContentViewController.reloadData(with: 4, completion: {
-                let expectedOffsetX = pagingContentViewController.scrollView.bounds.width * 4
+            pagingContentViewController.reloadData(with: 50, completion: {
+                let expectedOffsetX = pagingContentViewController.scrollView.bounds.width * 50
                 XCTAssertEqual(
                     pagingContentViewController.scrollView.contentOffset,
                     CGPoint(x: expectedOffsetX, y: 0),
@@ -103,8 +103,8 @@ class PagingContentViewControllerTests: XCTestCase {
         
         do {
             let expectation = XCTestExpectation(description: "index: 2")
-            pagingContentViewController.reloadData(with: 2, completion: {
-                let expectedOffsetX = pagingContentViewController.scrollView.bounds.width * 2
+            pagingContentViewController.reloadData(with: 98, completion: {
+                let expectedOffsetX = pagingContentViewController.scrollView.bounds.width * 98
                 XCTAssertEqual(
                     pagingContentViewController.scrollView.contentOffset,
                     CGPoint(x: expectedOffsetX, y: 0),
@@ -117,8 +117,8 @@ class PagingContentViewControllerTests: XCTestCase {
         
         do {
             let expectation = XCTestExpectation(description: "index: 5")
-            pagingContentViewController.reloadData(with: 5, completion: {
-                let expectedOffsetX = pagingContentViewController.scrollView.bounds.width * 5
+            pagingContentViewController.reloadData(with: 40, completion: {
+                let expectedOffsetX = pagingContentViewController.scrollView.bounds.width * 40
                 XCTAssertEqual(
                     pagingContentViewController.scrollView.contentOffset,
                     CGPoint(x: expectedOffsetX, y: 0),
@@ -188,7 +188,12 @@ class PagingContentVcDataSourceMock: NSObject, PagingContentViewControllerDataSo
 }
 
 class PagingContentVcDataSourceSpy: NSObject, PagingContentViewControllerDataSource {
-    let vcs: [UIViewController] = Array(repeating: UIViewController(), count: 5)
+    init(count: Int = 5) {
+        vcs = Array(repeating: UIViewController(), count: count)
+        super.init()
+    }
+    
+    let vcs: [UIViewController]
     
     func numberOfItemsForContentViewController(viewController: PagingContentViewController) -> Int {
         return vcs.count

--- a/PagingKitTests/PagingContentViewControllerTests.swift
+++ b/PagingKitTests/PagingContentViewControllerTests.swift
@@ -77,6 +77,61 @@ class PagingContentViewControllerTests: XCTestCase {
         self.dataSource = dataSource
     }
     
+    func testHookCompletionHandlerAfterReloadData() {
+        guard let pagingContentViewController = pagingContentViewController else {
+            XCTFail()
+            return
+        }
+
+        let dataSource = PagingContentVcDataSourceSpy()
+        pagingContentViewController.dataSource = dataSource
+        pagingContentViewController.loadViewIfNeeded()
+        
+        do {
+            let expectation = XCTestExpectation(description: "index: 4")
+            pagingContentViewController.reloadData(with: 4, completion: {
+                let expectedOffsetX = pagingContentViewController.scrollView.bounds.width * 4
+                XCTAssertEqual(
+                    pagingContentViewController.scrollView.contentOffset,
+                    CGPoint(x: expectedOffsetX, y: 0),
+                    "PagingContentViewController has completely finished reloading"
+                )
+                expectation.fulfill()
+            })
+            wait(for: [expectation], timeout: 1)
+        }
+        
+        do {
+            let expectation = XCTestExpectation(description: "index: 2")
+            pagingContentViewController.reloadData(with: 2, completion: {
+                let expectedOffsetX = pagingContentViewController.scrollView.bounds.width * 2
+                XCTAssertEqual(
+                    pagingContentViewController.scrollView.contentOffset,
+                    CGPoint(x: expectedOffsetX, y: 0),
+                    "PagingContentViewController has completely finished reloading"
+                )
+                expectation.fulfill()
+            })
+            wait(for: [expectation], timeout: 1)
+        }
+        
+        do {
+            let expectation = XCTestExpectation(description: "index: 5")
+            pagingContentViewController.reloadData(with: 5, completion: {
+                let expectedOffsetX = pagingContentViewController.scrollView.bounds.width * 5
+                XCTAssertEqual(
+                    pagingContentViewController.scrollView.contentOffset,
+                    CGPoint(x: expectedOffsetX, y: 0),
+                    "PagingContentViewController has completely finished reloading"
+                )
+                expectation.fulfill()
+            })
+            wait(for: [expectation], timeout: 1)
+        }
+
+        self.dataSource = dataSource
+    }
+    
     func testContentOffsetRatioInScrolling() {
         let expectation = XCTestExpectation(description: "finish reloadData")
         let dataSource = PagingContentVcDataSourceSpy()


### PR DESCRIPTION
The completionHandler of PagingMenuViewControllr.reloadData(with:completionHandler:) is sometimes not called.
I wrapped UIScrollView.setContentOffset() in UIView.animate(animation:completion:).