### PR TITLE
issue #47: Reflect content insets when scrolling

### DIFF
--- a/PagingKit/PagingContentViewController.swift
+++ b/PagingKit/PagingContentViewController.swift
@@ -248,7 +248,9 @@ public class PagingContentViewController: UIViewController {
         super.viewDidLoad()
         
         if #available(iOS 11.0, *) {
-            scrollView.contentInsetAdjustmentBehavior = .never
+            if scrollView.responds(to: #selector(setter: UIScrollView.contentInsetAdjustmentBehavior)) {
+                scrollView.contentInsetAdjustmentBehavior = .never
+            }
         }
         scrollView.frame = view.bounds
         scrollView.delegate = self

--- a/PagingKit/PagingMenuView.swift
+++ b/PagingKit/PagingMenuView.swift
@@ -385,11 +385,11 @@ public class PagingMenuView: UIScrollView {
     }
 
     var maxContentOffsetX: CGFloat {
-        return max(bounds.width, contentSize.width + contentSafeAreaInsets.right) - bounds.width
+        return max(bounds.width, contentSize.width + contentSafeAreaInsets.right + contentInset.right) - bounds.width
     }
     
     var minContentOffsetX: CGFloat {
-        return -contentSafeAreaInsets.left
+        return -(contentSafeAreaInsets.left + contentInset.left)
     }
     
     

--- a/PagingKit/PagingMenuView.swift
+++ b/PagingKit/PagingMenuView.swift
@@ -369,6 +369,7 @@ public class PagingMenuView: UIScrollView {
 
     var contentSafeAreaInsets: UIEdgeInsets {
         if #available(iOS 11.0, *) {
+            guard UIApplication.shared.delegate?.window??.responds(to: #selector(getter: safeAreaInsets)) ?? false else { return .zero }
             return safeAreaInsets
         } else {
             return .zero
@@ -567,6 +568,7 @@ public class PagingMenuView: UIScrollView {
     
     @available(iOS 11.0, *)
     public override func safeAreaInsetsDidChange() {
+        guard UIApplication.shared.delegate?.window??.responds(to: #selector(safeAreaInsetsDidChange)) ?? false else { return }
         super.safeAreaInsetsDidChange()
         alignEachVisibleCell()
     }


### PR DESCRIPTION
There are has Crash when approach to safe area insets.
So I add defense code.

And I Modify for Issue #47.

Thanks.