### PR TITLE
[FIX] Autolayout issue in example project.

### DIFF
--- a/iOS Sample/iOS Sample/OverlayFocusView.xib
+++ b/iOS Sample/iOS Sample/OverlayFocusView.xib
@@ -26,8 +26,8 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="AhR-eg-gSy" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="CeB-4e-CyK"/>
-                <constraint firstItem="AhR-eg-gSy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="XJX-N8-Zzt"/>
-                <constraint firstAttribute="trailing" secondItem="AhR-eg-gSy" secondAttribute="trailing" constant="8" id="voq-rB-VUn"/>
+                <constraint firstItem="AhR-eg-gSy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" priority="750" constant="8" id="XJX-N8-Zzt"/>
+                <constraint firstAttribute="trailing" secondItem="AhR-eg-gSy" secondAttribute="trailing" priority="750" constant="8" id="voq-rB-VUn"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>


### PR DESCRIPTION
I found autolayout issue in overlay example.

```
2018-10-01 18:58:54.241777+0900 iOS Sample[79048:94535865] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x6280000880c0 h=--& v=--& PagingKit.PagingMenuFocusView:0x7f927fd0a290.width == 0   (active)>",
    "<NSLayoutConstraint:0x6280000873a0 H:|-(8)-[UIView:0x7f927d4072d0]   (active, names: '|':iOS_Sample.OverlayFocusView:0x7f927d400cf0 )>",
    "<NSLayoutConstraint:0x6280000872b0 H:[UIView:0x7f927d4072d0]-(8)-|   (active, names: '|':iOS_Sample.OverlayFocusView:0x7f927d400cf0 )>",
    "<NSLayoutConstraint:0x6280000878f0 H:|-(0)-[iOS_Sample.OverlayFocusView:0x7f927d400cf0]   (active, names: '|':PagingKit.PagingMenuFocusView:0x7f927fd0a290 )>",
    "<NSLayoutConstraint:0x628000086540 iOS_Sample.OverlayFocusView:0x7f927d400cf0.trailing == PagingKit.PagingMenuFocusView:0x7f927fd0a290.trailing   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x6280000872b0 H:[UIView:0x7f927d4072d0]-(8)-|   (active, names: '|':iOS_Sample.OverlayFocusView:0x7f927d400cf0 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKit/UIView.h> may also be helpful.
```