### PR TITLE
Fix layout error of PagingMenuView

### DIFF
--- a/PagingKit/PagingMenuView.swift
+++ b/PagingKit/PagingMenuView.swift
@@ -253,9 +253,12 @@ open class PagingMenuView: UIScrollView {
     }
     
     open func registerFocusView(view: UIView, isBehindCell: Bool = false) {
+        view.translatesAutoresizingMaskIntoConstraints = true
+        view.autoresizingMask = [.flexibleLeftMargin, .flexibleTopMargin, .flexibleWidth, .flexibleHeight]
+        view.frame = focusView.bounds
         focusView.addSubview(view)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        focusView.addConstraints([.top, .bottom, .leading, .trailing].anchor(from: view, to: focusView))
+
+//        focusView.addConstraints([.top, .bottom, .leading, .trailing].anchor(from: view, to: focusView))
         focusView.layer.zPosition = isBehindCell ? -1 : 0
     }
     
@@ -438,7 +441,7 @@ open class PagingMenuView: UIScrollView {
     }
     
     private func configureFocusView() {
-        focusView.frame = .zero
+        focusView.frame = CGRect(x: 0, y: 0, width: 1, height: 1) // to avoid ignoring focus view's layout
         containerView.addSubview(focusView)
     }
     

--- a/PagingKit/PagingMenuView.swift
+++ b/PagingKit/PagingMenuView.swift
@@ -253,12 +253,9 @@ open class PagingMenuView: UIScrollView {
     }
     
     open func registerFocusView(view: UIView, isBehindCell: Bool = false) {
-        view.translatesAutoresizingMaskIntoConstraints = true
         view.autoresizingMask = [.flexibleLeftMargin, .flexibleTopMargin, .flexibleWidth, .flexibleHeight]
         view.frame = focusView.bounds
         focusView.addSubview(view)
-
-//        focusView.addConstraints([.top, .bottom, .leading, .trailing].anchor(from: view, to: focusView))
         focusView.layer.zPosition = isBehindCell ? -1 : 0
     }
     

--- a/iOS Sample/iOS Sample.xcodeproj/project.pbxproj
+++ b/iOS Sample/iOS Sample.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2B140598218EB84C00474615 /* NavigationBarMenuCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2B140597218EB84C00474615 /* NavigationBarMenuCell.xib */; };
+		2B14059A218EB8A000474615 /* NavigationBarMenuCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B140599218EB8A000474615 /* NavigationBarMenuCell.swift */; };
+		2B14059C218EBAC200474615 /* NavigationBarFocusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B14059B218EBAC200474615 /* NavigationBarFocusView.swift */; };
+		2B14059E218EBAE600474615 /* NavigationBarFocusView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2B14059D218EBAE600474615 /* NavigationBarFocusView.xib */; };
 		2B3C7CC51F8CEB0100A43223 /* TwoLineMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3C7CC41F8CEB0100A43223 /* TwoLineMenuViewController.swift */; };
 		2B3C7CC71F8CEB0900A43223 /* TwoLineMenuViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2B3C7CC61F8CEB0900A43223 /* TwoLineMenuViewController.storyboard */; };
 		2B3C7CC91F8CEF1200A43223 /* TwoLineMenuCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3C7CC81F8CEF1200A43223 /* TwoLineMenuCell.swift */; };
@@ -94,6 +98,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2B140597218EB84C00474615 /* NavigationBarMenuCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NavigationBarMenuCell.xib; sourceTree = "<group>"; };
+		2B140599218EB8A000474615 /* NavigationBarMenuCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarMenuCell.swift; sourceTree = "<group>"; };
+		2B14059B218EBAC200474615 /* NavigationBarFocusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarFocusView.swift; sourceTree = "<group>"; };
+		2B14059D218EBAE600474615 /* NavigationBarFocusView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NavigationBarFocusView.xib; sourceTree = "<group>"; };
 		2B3C7CC41F8CEB0100A43223 /* TwoLineMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoLineMenuViewController.swift; sourceTree = "<group>"; };
 		2B3C7CC61F8CEB0900A43223 /* TwoLineMenuViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TwoLineMenuViewController.storyboard; sourceTree = "<group>"; };
 		2B3C7CC81F8CEF1200A43223 /* TwoLineMenuCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoLineMenuCell.swift; sourceTree = "<group>"; };
@@ -182,6 +190,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2B14059F218EBD7200474615 /* NavigationBar */ = {
+			isa = PBXGroup;
+			children = (
+				2B7F2E62217EBF0800523F2E /* NavigationBarVIewController.storyboard */,
+				2B7F2E63217EBF1400523F2E /* NavigationBarViewController.swift */,
+				2B140597218EB84C00474615 /* NavigationBarMenuCell.xib */,
+				2B140599218EB8A000474615 /* NavigationBarMenuCell.swift */,
+				2B14059B218EBAC200474615 /* NavigationBarFocusView.swift */,
+				2B14059D218EBAE600474615 /* NavigationBarFocusView.xib */,
+			);
+			name = NavigationBar;
+			sourceTree = "<group>";
+		};
 		2B3C7CC31F8CEAB800A43223 /* TwoLineMenu */ = {
 			isa = PBXGroup;
 			children = (
@@ -349,8 +370,7 @@
 		6E9827781F0A91F400860828 /* iOS Sample */ = {
 			isa = PBXGroup;
 			children = (
-				2B7F2E62217EBF0800523F2E /* NavigationBarVIewController.storyboard */,
-				2B7F2E63217EBF1400523F2E /* NavigationBarViewController.swift */,
+				2B14059F218EBD7200474615 /* NavigationBar */,
 				2BC782882127ECEE009999F6 /* InitializingWithoutStoryboard */,
 				2B40528F20425C6C0017F90E /* DynamicWidth */,
 				2B95EA06203164890054F23E /* Alignment */,
@@ -516,6 +536,7 @@
 			files = (
 				2B40529120425C800017F90E /* DynamicWidthViewController.storyboard in Resources */,
 				2B95EA08203164AA0054F23E /* AlignmentViewController.storyboard in Resources */,
+				2B140598218EB84C00474615 /* NavigationBarMenuCell.xib in Resources */,
 				2BE47F081FA41AF40057A786 /* FullscreenViewController.storyboard in Resources */,
 				2B873AE31F974B3900F02D27 /* ModalViewController.storyboard in Resources */,
 				2B3C7CCB1F8CEF2200A43223 /* TwoLineMenuCell.xib in Resources */,
@@ -532,6 +553,7 @@
 				2B45419B1FA490B600A9B253 /* PhotoViewController.storyboard in Resources */,
 				6E9827811F0A91F400860828 /* Assets.xcassets in Resources */,
 				2BBB70E81F9234C100320900 /* DynamicSizeViewController.storyboard in Resources */,
+				2B14059E218EBAE600474615 /* NavigationBarFocusView.xib in Resources */,
 				2B47E7321F109D8D00D67C04 /* OverlayFocusView.xib in Resources */,
 				2B95EA03203157B70054F23E /* MenuReloadableViewController.storyboard in Resources */,
 				2B4F034E1F9057380015FCC8 /* ContentTableViewController.storyboard in Resources */,
@@ -564,6 +586,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2B14059A218EB8A000474615 /* NavigationBarMenuCell.swift in Sources */,
 				6E9827BF1F0A958900860828 /* ContentViewController.swift in Sources */,
 				2BE47F0A1FA41B090057A786 /* FullscreenViewController.swift in Sources */,
 				2BFA4AC31F0CEC39001B9BCA /* ModalViewController.swift in Sources */,
@@ -578,6 +601,7 @@
 				2BC7828A2127ED11009999F6 /* InitializingWithoutStoryboardViewController.swift in Sources */,
 				2B4F03521F905B930015FCC8 /* ContentTableViewCell.swift in Sources */,
 				2B3C7CC91F8CEF1200A43223 /* TwoLineMenuCell.swift in Sources */,
+				2B14059C218EBAC200474615 /* NavigationBarFocusView.swift in Sources */,
 				2B45419D1FA490BE00A9B253 /* PhotoViewController.swift in Sources */,
 				2B47F87A1F5BF173001A7D2B /* DynamicSizeViewController.swift in Sources */,
 				2B7F2E65217EBF1400523F2E /* NavigationBarViewController.swift in Sources */,

--- a/iOS Sample/iOS Sample/NavigationBarFocusView.swift
+++ b/iOS Sample/iOS Sample/NavigationBarFocusView.swift
@@ -1,0 +1,30 @@
+//
+//  NavigationBarFocusView.swift
+//  iOS Sample
+//
+//  Copyright (c) 2018 Kazuhiro Hayashi
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import UIKit
+import PagingKit
+
+class NavigationBarFocusView: PagingMenuFocusView {
+
+}

--- a/iOS Sample/iOS Sample/NavigationBarFocusView.xib
+++ b/iOS Sample/iOS Sample/NavigationBarFocusView.xib
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="NavigationBarFocusView" customModule="iOS_Sample" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xZu-VZ-aC9">
+                    <rect key="frame" x="0.0" y="663" width="375" height="4"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                    <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="138.40000000000001" y="152.47376311844079"/>
+        </view>
+    </objects>
+</document>

--- a/iOS Sample/iOS Sample/NavigationBarMenuCell.swift
+++ b/iOS Sample/iOS Sample/NavigationBarMenuCell.swift
@@ -1,0 +1,39 @@
+//
+//  NavigationBarMenuCell.swift
+//  iOS Sample
+//
+//  Copyright (c) 2018 Kazuhiro Hayashi
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import UIKit
+import PagingKit
+
+class NavigationBarMenuCell: PagingMenuViewCell {
+
+    @IBOutlet weak var titleLabel: UILabel!
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/iOS Sample/iOS Sample/NavigationBarMenuCell.xib
+++ b/iOS Sample/iOS Sample/NavigationBarMenuCell.xib
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="NavigationBarMenuCell" customModule="iOS_Sample" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="03V-if-lci">
+                    <rect key="frame" x="0.0" y="0.0" width="370" height="667"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" heightSizable="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <connections>
+                <outlet property="titleLabel" destination="03V-if-lci" id="arR-4o-FKo"/>
+            </connections>
+            <point key="canvasLocation" x="138.40000000000001" y="152.47376311844079"/>
+        </view>
+    </objects>
+</document>

--- a/iOS Sample/iOS Sample/NavigationBarViewController.swift
+++ b/iOS Sample/iOS Sample/NavigationBarViewController.swift
@@ -33,9 +33,8 @@ class NavigationBarViewController: UIViewController {
         menuView.dataSource = self
         menuView.menuDelegate = self
         menuView.cellAlignment = .center
-        
-        menuView.register(type: TitleLabelMenuViewCell.self, with: "identifier")
-        menuView.registerFocusView(view: UnderlineFocusView())
+        menuView.register(nib: UINib(nibName: "NavigationBarMenuCell", bundle: nil), with: "identifier")
+        menuView.registerFocusView(nib: UINib(nibName: "NavigationBarFocusView", bundle: nil))
         return menuView
     }()
     var contentViewController: PagingContentViewController?
@@ -87,7 +86,7 @@ extension NavigationBarViewController: PagingMenuViewDataSource {
     }
     
     func pagingMenuView(pagingMenuView: PagingMenuView, cellForItemAt index: Int) -> PagingMenuViewCell {
-        let cell = pagingMenuView.dequeue(with: "identifier") as! TitleLabelMenuViewCell
+        let cell = pagingMenuView.dequeue(with: "identifier") as! NavigationBarMenuCell
         cell.titleLabel.text = dataSource[index].menu
         cell.backgroundColor = .clear
         return cell


### PR DESCRIPTION
To Support navigation bar 

https://github.com/kazuhiro4949/PagingKit/issues/71

UIViewController.navigationItem.titleVIew breaks the subview's layout when the view controller assign any views with autotlayout to titleView.

UIPagingMenuView doesn't have auto layout any longer in pull-request.