### PR TITLE
fixed Podspec to exclude Info.plist file

### DIFF
--- a/PagingKit.podspec
+++ b/PagingKit.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
 
-  s.source_files = "PagingKit/*"
+  s.source_files = "PagingKit/**/*.{h,m,swift}"
 end


### PR DESCRIPTION
Our project is not building on Xcode 11 because the Info.plist file is included in the compile sources build phase.

This fixes that problem by only including actual source files.