### PR TITLE
focusView.selectedIndex should be `> 0`

### DIFF
--- a/PagingKit/PagingMenuView.swift
+++ b/PagingKit/PagingMenuView.swift
@@ -421,7 +421,7 @@ open class PagingMenuView: UIScrollView {
         focusView.center = CGPoint(x: centerPointX, y: center.y)
         
         let expectedIndex = (focusView.center.x < leftFrame.maxX) ? index : rightIndex
-        focusView.selectedIndex = min(expectedIndex, numberOfItem - 1)
+        focusView.selectedIndex = max(0, min(expectedIndex, numberOfItem - 1))
         
         contentOffset = CGPoint(x: normaizedOffsetX, y:0)
         


### PR DESCRIPTION
Hi.
Thank you for creating this library!

I encountered the situation: `focusView.selectedIndex` is `-1`.

1. Load PagingMenuViewController with empty item
2. At this time, `focusView.selectedIndex` is `-1`.
3. Reload the PagingMenuViewController with some items by `menuViewController.reloadData(with: 0)`
4. `focusView.selectedIndex` is still `-1`. So no focus view appeared.

I think focusView.selectedIndex should not be `-1`.
