### PR TITLE
Stop resetting OverlayMenuCell.highlightLabel.textColor to white in layoutSubviews

### DIFF
--- a/PagingKit/Menu Cells/Overlay/OverlayMenuCell.swift
+++ b/PagingKit/Menu Cells/Overlay/OverlayMenuCell.swift
@@ -77,7 +77,6 @@ public class OverlayMenuCell: PagingMenuViewCell {
     override public func layoutSubviews() {
         super.layoutSubviews()
         textMaskView.bounds = bounds.inset(by: maskInsets)
-        highlightLabel.textColor = .white
     }
     
     public func configure(title: String) {


### PR DESCRIPTION
Setting hightlightTextColor is meaningless if the property is always reset to white.