### PR TITLE
Open init for FocusView.

### DIFF
--- a/Sources/PagingMenuView.swift
+++ b/Sources/PagingMenuView.swift
@@ -86,7 +86,7 @@ open class PagingMenuFocusViewAnimationCoordinator {
 open class PagingMenuFocusView: UIView {
     open var selectedIndex: Int?
     
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .clear
     }


### PR DESCRIPTION
When implementing FocusView without using nib, init cannot be overridden.

<img width="789" alt="CleanShot 2022-02-18 at 14 56 57@2x" src="https://user-images.githubusercontent.com/2066707/154626405-ed832957-f322-4b43-aa8b-056e1e018558.png">

